### PR TITLE
update_engine: add TARGET_ENFORCE_AB_OTA_PARTITION_LIST variable

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -183,6 +183,13 @@ cc_library_static {
         "payload_consumer/xz_extent_writer.cc",
         "payload_consumer/fec_file_descriptor.cc",
     ],
+    product_variables: {
+        omnirom: {
+            target_enforce_ab_ota_partition_list: {
+                cflags: ["-DTARGET_ENFORCE_AB_OTA_PARTITION_LIST"],
+            },
+        },
+    },
 }
 
 // libupdate_engine_boot_control (type: static_library)
@@ -506,6 +513,13 @@ cc_library_static {
         "payload_generator/topological_sort.cc",
         "payload_generator/xz_android.cc",
     ],
+    product_variables: {
+        omnirom: {
+            target_enforce_ab_ota_partition_list: {
+                cflags: ["-DTARGET_ENFORCE_AB_OTA_PARTITION_LIST"],
+            },
+        },
+    },
 }
 
 // delta_generator (type: executable)

--- a/payload_consumer/delta_performer.cc
+++ b/payload_consumer/delta_performer.cc
@@ -952,6 +952,9 @@ bool DeltaPerformer::InitPartitionMetadata() {
       for (const auto& partition_name : group.partition_names()) {
         auto it = partition_sizes.find(partition_name);
         if (it == partition_sizes.end()) {
+#ifdef TARGET_ENFORCE_AB_OTA_PARTITION_LIST
+          continue;
+#else
           // TODO(tbao): Support auto-filling partition info for framework-only
           // OTA.
           LOG(ERROR) << "dynamic_partition_metadata contains partition "
@@ -959,6 +962,7 @@ bool DeltaPerformer::InitPartitionMetadata() {
                      << " but it is not part of the manifest. "
                      << "This is not supported.";
           return false;
+#endif
         }
         e.partitions.push_back({partition_name, it->second});
       }
@@ -967,7 +971,12 @@ bool DeltaPerformer::InitPartitionMetadata() {
   }
 
   bool metadata_updated = false;
+#ifdef TARGET_ENFORCE_AB_OTA_PARTITION_LIST
+  LOG(INFO) << "Skip metadata update because device has set TARGET_ENFORCE_AB_OTA_PARTITION_LIST";
+  metadata_updated = true;
+#else
   prefs_->GetBoolean(kPrefsDynamicPartitionMetadataUpdated, &metadata_updated);
+#endif
   if (!boot_control_->InitPartitionMetadata(
           install_plan_->target_slot, partition_metadata, !metadata_updated)) {
     LOG(ERROR) << "Unable to initialize partition metadata for slot "

--- a/payload_generator/payload_generation_config.cc
+++ b/payload_generator/payload_generation_config.cc
@@ -169,6 +169,10 @@ bool ImageConfig::ValidateDynamicPartitionMetadata() const {
     LOG(ERROR) << "dynamic_partition_metadata is not loaded.";
     return false;
   }
+#ifdef TARGET_ENFORCE_AB_OTA_PARTITION_LIST
+  LOG(INFO) << "Skip ValidateDynamicPartitionMetadata because device has set TARGET_ENFORCE_AB_OTA_PARTITION_LIST";
+  return true;
+#endif
 
   for (const auto& group : dynamic_partition_metadata->groups()) {
     uint64_t sum_size = 0;


### PR DESCRIPTION
this prevents ab updates to change the super partition tables
we never want to do that during regular weekly updates
and e.g. vendor and odm partitions should stay untouched
with stock contents

Change-Id: I5d9d4df718ee96400bbf519b4989b60ca2c2111e